### PR TITLE
Add detection for redis unauthorized access (covers CVE-2022-20821)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ For the moment, we are currently focused on the CISA KEV Database and Google Tsu
 | CVE-2015-0666                                           | ⌛           | Pending.                                               |
 | CVE-2022-26871                                          | ⌛           | Pending.                                               |
 | CVE-2021-27852                                          | ⌛           | Pending.                                               |
-| CVE-2022-20821                                          | ⌛           | Pending.                                               |
 | CVE-2016-8735                                           | ⌛           | Pending.                                               |
 | CVE-2020-2551                                           | ⌛           | Pending.                                               |
 | CVE-2023-6345                                           | ⌛           | Pending.                                               |
@@ -319,6 +318,7 @@ For the moment, we are currently focused on the CISA KEV Database and Google Tsu
 | CVE-2022-21919                                          | ❌           | Not remotely exploitable/User interaction needed.      |
 | CVE-2022-21882                                          | ❌           | Not remotely exploitable/User interaction needed.      |
 | CVE-2022-21587                                          | ✅           | Nuclei Template was used.                              |
+| CVE-2022-20821                                          | ✅           | Custom Nuclei template by Ostorlab.                    |
 | CVE-2022-20708                                          | ❌           | Not remotely exploitable/User interaction needed.      |
 | CVE-2022-20703                                          | ❌           | Not remotely exploitable/User interaction needed.      |
 | CVE-2022-20701                                          | ❌           | Not remotely exploitable/User interaction needed.      |

--- a/agent_group.yaml
+++ b/agent_group.yaml
@@ -211,6 +211,7 @@ agents:
             - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2023-6553.yaml
             - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2023-49103.yaml
             - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2023-41266.yaml
+            - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/redis-unauthorized-access.yaml
       - name: use_default_templates
         type: boolean
         description: use nuclei's default templates to scan.

--- a/nuclei/redis-unauthorized-access.yaml
+++ b/nuclei/redis-unauthorized-access.yaml
@@ -1,0 +1,59 @@
+id: redis-unauthorized-access
+
+info:
+  name: Redis Unauthorized Access Vulnerability
+  author: Mohamed Benchikh
+  severity: high
+  description:
+    The Redis server running on the remote host is not protected by password authentication. 
+    A remote attacker can exploit this to gain unauthorized access to the server.
+  reference:
+    - https://redis.io/topics/security
+    - https://www.secpod.com/blog/cisco-ios-xr-zero-day-vulnerability-being-actively-exploited-in-the-wild/
+  classification:
+    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
+    cvss-score: 7.2
+    cwe-id: CWE-306
+    cve-id: CVE-2022-20821,CVE-2018-0181
+  metadata:
+    max-request: 4
+  tags: network,redis,unauth,exposure,cve-2022-20821
+
+tcp:
+  - inputs:
+      - data: "info\r\nquit\r\n"
+
+    host:
+      - "{{Hostname}}"
+      - "tls://{{Hostname}}"
+    port: 6380
+    read-size: 2048
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "redis_version"
+      - type: word
+        negative: true
+        words:
+          - "redis_mode:sentinel"
+
+  - inputs:
+    - data: "info\r\nquit\r\n"
+
+    host:
+      - "{{Hostname}}"
+      - "tls://{{Hostname}}"
+    port: 6379
+    read-size: 2048
+
+    matchers-condition: and
+    matchers:
+      - type: word
+        words:
+          - "redis_version"
+      - type: word
+        negative: true
+        words:
+          - "redis_mode:sentinel"


### PR DESCRIPTION
Official Nuclei template for exposed redis doesn't cover port `6379` which is the port used Cisco in CVE-2022-20821 for which I created a custom template based on the official one by pdteam.