### PR TITLE
feature: add nuclei template for php object injection (cve-2026-2599)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ For the moment, we are currently focused on the CISA KEV Database and Google Tsu
 
 | CVE ID                                                  | Implemented | Detail                                                  | Published Date |
 |:--------------------------------------------------------|:-----------:|:--------------------------------------------------------|:--------------:|
+| CVE-2026-2599                                          |      ✅      | Custom Nuclei template by Ostorlab.        |   2026-03-12   |
 | CVE-2026-27971                                          |      ✅      | Official Nuclei template (modified by Ostorlab) .        |   2026-03-12   |
 | CVE-2025-68461                                          |      ✅      | Official Nuclei template by Ostorlab .        |   2026-03-04   |
 | CVE-2026-0770                                          |      ✅      | Official Nuclei template (modified by Ostorlab).        |   2026-03-02   |

--- a/agent_group.yaml
+++ b/agent_group.yaml
@@ -347,6 +347,7 @@ agents:
             - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2026-0770.yaml
             - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2025-68461.yaml
             - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2026-27971.yaml
+            - https://raw.githubusercontent.com/Ostorlab/known_exploited_vulnerbilities_detectors/main/nuclei/CVE-2026-2599.yaml
       - name: use_default_templates
         type: boolean
         description: use nuclei's default templates to scan.

--- a/nuclei/CVE-2026-2599.yaml
+++ b/nuclei/CVE-2026-2599.yaml
@@ -1,0 +1,79 @@
+id: CVE-2026-2599
+
+info:
+  name: WordPress Contact Form Entries <= 1.4.7 - Unauthenticated PHP Object Injection
+  author: soop
+  severity: critical
+  description: |
+    The Database for Contact Form 7, WPforms, Elementor forms plugin for WordPress is vulnerable
+    to PHP Object Injection in all versions up to and including 1.4.7 via deserialization of
+    untrusted input in the 'download_csv' function. Unauthenticated attackers can inject PHP Objects.
+    No POP chain exists in the plugin itself, but if one is present via another plugin or WordPress
+    core (e.g., WP_HTML_Token in WordPress 6.4.0-6.4.1), this leads to Remote Code Execution.
+  remediation: Update Contact Form Entries plugin to version 1.4.8 or later.
+  reference:
+    - https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/contact-form-entries/database-for-contact-form-7-wpforms-elementor-forms-147-unauthenticated-php-object-injection-via-download-csv
+    - https://plugins.trac.wordpress.org/changeset/3249938/contact-form-entries
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2026-2599
+    cwe-id: CWE-502
+  metadata:
+    verified: true
+    max-request: 2
+    vendor: crmperks
+    product: contact-form-entries
+    framework: wordpress
+    google-query: inurl:"/wp-content/plugins/contact-form-entries/readme.txt"
+  tags: cve,cve2026,wordpress,wp-plugin,contact-form-entries,deserialization,rce,unauth,critical
+
+flow: http(1) && http(2)
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/wp-content/plugins/contact-form-entries/readme.txt"
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: word
+        part: body
+        words:
+          - "=== Database for Contact Form 7"
+          - "crmperks"
+        condition: and
+
+      - type: regex
+        part: body
+        regex:
+          - '(?i)Stable\s*tag:\s*1\.([0-3]\.\d+|4\.[0-7])(\s|$)'
+
+    extractors:
+      - type: regex
+        name: vulnerable-to-deserialization
+        group: 1
+        regex:
+          - '(?i)Stable\s*tag:\s*([\w.]+)'
+
+  # WP_HTML_Token POP chain: introduced in WP 6.4.0, patched with __wakeup in 6.4.2
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - 'content="WordPress\s+6\.4\.[01]"'
+
+    extractors:
+      - type: regex
+        name: WP_HTML_Token-POP-chain-full-RCE-exploitable-on-version
+        group: 1
+        regex:
+          - 'content="WordPress\s+([\d.]+)"'


### PR DESCRIPTION
The template uses 2-step detection to differentiate between general vulnerability and immediate RCE risk:

  Step 1: Plugin Vulnerability Detection

   - Fetches /wp-content/plugins/contact-form-entries/readme.txt
   - Validates plugin identity (exact header + vendor slug)
   - Checks version using regex: 1.([0-3].\d+|4.[0-7]) (matches
    1.0.0 through 1.4.7)
   - Output: vulnerable-to-deserialization: ["1.4.7"]

  Step 2: POP Chain Detection (conditional)

   - Only runs if Step 1 matched
   - Checks homepage meta tag for WordPress version
   - Matches only 6.4.0 or 6.4.1 (vulnerable window)
   - Output: WP_HTML_Token-POP-chain-full-RCE-exploitable-on-version: ["6.4.1"]
